### PR TITLE
Fixed condition for adding to list swap op

### DIFF
--- a/Interpreter/Lexer.cpp
+++ b/Interpreter/Lexer.cpp
@@ -39,6 +39,7 @@ void Lexer::run() {
       char next = line[i+1];
       // Determine if the current charater could be the start of a keyword
       if (isIdentifierStart(current, next)) {
+        char charAfterIdentifier = line[i];
         // Collect token type and string of identifier
         Token temp = readIdentifierOrKeyword(line, i);
         // Check if token is a non return keyword or built in function
@@ -48,7 +49,7 @@ void Lexer::run() {
         else if (temp.tokenType == TokenType::RETURN) {
           return_swap_op = tokenized_line.size();
         }
-        else if (temp.tokenType == TokenType::VARIABLE && next == '[') {
+        else if (temp.tokenType == TokenType::VARIABLE && charAfterIdentifier == '[') {
           //Addtoken string object to converted line
           list_swap_op.push_back(tokenized_line.size());
         }


### PR DESCRIPTION
the swap from arr[i] to [i]arr wasnt happening because the condition for adding the list swap of was wrong, this is now working. however it still does not in fstrings. i think that tokenizing a line should become a function and then the contents of an fstring can the be analysed as a seperate line. even though the swap is working now program will still crash idk why but you probably do